### PR TITLE
Add `autodistill-remote-clip` to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Jiale Zhu (朱佳乐)
 
 
 ### News
+- **2023/12/01**: You can now auto-label remote sensing datasets with RemoteCLIP using the [`autodistill-remote-clip`](https://github.com/autodistill/autodistill-remote-clip) extension.
+  
 - **2023/11/07**: To facilitate reproducing RemoteCLIP's SOTA image-text retrieval results, we have prepared a `retrieval.py` script for retrieval evaluation on RSITMD, RSICD, and UCM datasets. Please see the [Retrieval Evaluation](#retrieval-evaluation) section for details.
 
 - **2023/07/27**: We make pretrained checkpoints of RemoteCLIP models (`ResNet-50`, `ViT-base-32`, and `ViT-large-14`) available! We converted the weights to the [`OpenCLIP`](https://github.com/mlfoundations/open_clip) format, such that loading and using RemoteCLIP is extremely easy! Please see the [Load RemoteCLIP](#load-remoteclip) section for details. We also provide a Jupyter Notebook [demo.ipynb](demo.ipynb), and you can also [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ChenDelong1999/RemoteCLIP/blob/main/RemoteCLIP_colab_demo.ipynb).


### PR DESCRIPTION
Hello there! I am an engineer at Roboflow. I added RemoteCLIP to [Autodistill](https://github.com/autodistill/autodistill) a framework for auto-labeling datasets with foundation models. Using this extension, you can auto-label a folder of images with RemoteCLIP, and use the resulting dataset to train a fine-tuned classification model.

You can also use RemoteCLIP with the new `[ComposedDetectionModel](https://blog.roboflow.com/label-product-skus/)` API, allowing you to use a detection model to find objects of interest, then RemoteCLIP to classify each region. I thought I'd PR the feature here so people can use your research for auto-labeling!